### PR TITLE
Back up minimum Swift version to 6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0.3
+// swift-tools-version: 6.0
 
 import PackageDescription
 


### PR DESCRIPTION
Xcode doesn't ship with 6.0.3